### PR TITLE
fix invalid master keys after an auto backup occured

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,9 +14,7 @@ repositories {
 android {
     compileSdk = 31
     defaultConfig {
-        applicationId = "photos.network"
-        // API 21 | required by: security-crypto library
-        // API 23 | required by: security.crypto.MasterKey
+        applicationId = "photos.network.android"
         minSdk = 23
         targetSdk = 31
         versionCode = 1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,7 +154,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
 
-    implementation("androidx.security:security-crypto:1.0.0")
+    implementation("androidx.security:security-crypto:1.1.0-alpha03")
     implementation("com.google.code.gson:gson:2.8.6")
 
     // testing

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,9 @@ repositories {
 android {
     compileSdk = 31
     defaultConfig {
-        applicationId = "photos.network.android"
+        applicationId = "photos.network"
+        // API 21 | required by: security-crypto library
+        // API 23 | required by: security.crypto.MasterKey
         minSdk = 23
         targetSdk = 31
         versionCode = 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
     <!--  use precise location coordinates  -->
     <uses-feature android:name="android.hardware.location.gps" android:required="false"/>
 
-    <!-- disable backup to prevent missing keyset for encrypted storage -->
+    <!-- exclude encrypted files from backup to prevent decryption errors like: AEADBadTagException -->
     <application
         android:name=".PhotosNetworkApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,8 +23,11 @@
     <!--  use precise location coordinates  -->
     <uses-feature android:name="android.hardware.location.gps" android:required="false"/>
 
+    <!-- disable backup to prevent missing keyset for encrypted storage -->
     <application
         android:name=".PhotosNetworkApplication"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/network/photos/android/data/settings/storage/SettingsStorage.kt
+++ b/app/src/main/java/network/photos/android/data/settings/storage/SettingsStorage.kt
@@ -1,9 +1,11 @@
 package network.photos.android.data.settings.storage
 
 import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 import android.util.Log
 import androidx.security.crypto.EncryptedFile
-import androidx.security.crypto.MasterKeys
+import androidx.security.crypto.MasterKey
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import network.photos.android.data.settings.domain.Settings
@@ -17,20 +19,41 @@ import java.nio.charset.StandardCharsets
  * Read/Write settings encrypted into internal storage
  */
 class SettingsStorage(private val context: Context) {
-    private val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+    private val masterKeyAlias = "settings_storage"
     private val filename = "settings_storage.txt"
     private val gson: Gson = GsonBuilder().create()
     private val secureFile = File(context.filesDir, filename)
+    private lateinit var masterKey: MasterKey
+    private lateinit var encryptedFile: EncryptedFile
+
+    init {
+        try {
+            val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+                masterKeyAlias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(256)
+                .build()
+
+            masterKey = MasterKey.Builder(context, masterKeyAlias)
+                .setKeyGenParameterSpec(keyGenParameterSpec)
+                .build()
+
+            encryptedFile = EncryptedFile.Builder(
+                context.applicationContext,
+                secureFile,
+                masterKey,
+                EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+            ).build()
+        } catch (e: Exception) {
+            Log.e("SettingsStr", "\uD83D\uDC80 EXCEPTION!!", e)
+            delete()
+        }
+    }
 
     fun readSettings(): Settings? {
         try {
-            val encryptedFile = EncryptedFile.Builder(
-                secureFile,
-                context.applicationContext,
-                masterKeyAlias,
-                EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
-            ).build()
-
             var inputStream: FileInputStream? = null
             try {
                 inputStream = encryptedFile.openFileInput()
@@ -49,11 +72,14 @@ class SettingsStorage(private val context: Context) {
                 return gson.fromJson(jsonString, Settings::class.java)
             } catch (e: Exception) {
                 // Log exceptions
+
             } finally {
                 inputStream?.close()
             }
         } catch (e: FileNotFoundException) {
             Log.w("SettingsStr", "No previous saved settings found.")
+        } catch (e: Exception) {
+            Log.e("SettingsStr", "\uD83D\uDC80 EXCEPTION!!", e)
         }
 
         return null
@@ -77,6 +103,12 @@ class SettingsStorage(private val context: Context) {
             write(jsonString.toByteArray(StandardCharsets.UTF_8))
             flush()
             close()
+        }
+    }
+
+    fun delete() {
+        if (secureFile.exists()) {
+            secureFile.delete()
         }
     }
 }

--- a/app/src/main/java/network/photos/android/data/settings/storage/SettingsStorage.kt
+++ b/app/src/main/java/network/photos/android/data/settings/storage/SettingsStorage.kt
@@ -29,30 +29,35 @@ class SettingsStorage(private val context: Context) {
 
     init {
         try {
-            val keyGenParameterSpec = KeyGenParameterSpec
-                .Builder(
-                    DEFAULT_MASTER_KEY_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setKeySize(DEFAULT_AES_GCM_MASTER_KEY_SIZE)
-                .build()
-
-            masterKey = MasterKey.Builder(context, DEFAULT_MASTER_KEY_ALIAS)
-                .setKeyGenParameterSpec(keyGenParameterSpec)
-                .build()
-
-            encryptedFile = EncryptedFile.Builder(
-                context.applicationContext,
-                secureFile,
-                masterKey,
-                EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
-            ).build()
+            initialize(context)
         } catch (e: Exception) {
             Log.e("SettingsStr", "\uD83D\uDC80 EXCEPTION!!", e)
             delete()
+            initialize(context)
         }
+    }
+
+    private fun initialize(context: Context) {
+        val keyGenParameterSpec = KeyGenParameterSpec
+            .Builder(
+                DEFAULT_MASTER_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(DEFAULT_AES_GCM_MASTER_KEY_SIZE)
+            .build()
+
+        masterKey = MasterKey.Builder(context, DEFAULT_MASTER_KEY_ALIAS)
+            .setKeyGenParameterSpec(keyGenParameterSpec)
+            .build()
+
+        encryptedFile = EncryptedFile.Builder(
+            context.applicationContext,
+            secureFile,
+            masterKey,
+            EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+        ).build()
     }
 
     fun readSettings(): Settings? {

--- a/app/src/main/java/network/photos/android/data/settings/storage/SettingsStorage.kt
+++ b/app/src/main/java/network/photos/android/data/settings/storage/SettingsStorage.kt
@@ -6,6 +6,8 @@ import android.security.keystore.KeyProperties
 import android.util.Log
 import androidx.security.crypto.EncryptedFile
 import androidx.security.crypto.MasterKey
+import androidx.security.crypto.MasterKey.DEFAULT_AES_GCM_MASTER_KEY_SIZE
+import androidx.security.crypto.MasterKey.DEFAULT_MASTER_KEY_ALIAS
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import network.photos.android.data.settings.domain.Settings
@@ -19,7 +21,6 @@ import java.nio.charset.StandardCharsets
  * Read/Write settings encrypted into internal storage
  */
 class SettingsStorage(private val context: Context) {
-    private val masterKeyAlias = "settings_storage"
     private val filename = "settings_storage.txt"
     private val gson: Gson = GsonBuilder().create()
     private val secureFile = File(context.filesDir, filename)
@@ -28,15 +29,17 @@ class SettingsStorage(private val context: Context) {
 
     init {
         try {
-            val keyGenParameterSpec = KeyGenParameterSpec.Builder(
-                masterKeyAlias,
-                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-            ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            val keyGenParameterSpec = KeyGenParameterSpec
+                .Builder(
+                    DEFAULT_MASTER_KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setKeySize(256)
+                .setKeySize(DEFAULT_AES_GCM_MASTER_KEY_SIZE)
                 .build()
 
-            masterKey = MasterKey.Builder(context, masterKeyAlias)
+            masterKey = MasterKey.Builder(context, DEFAULT_MASTER_KEY_ALIAS)
                 .setKeyGenParameterSpec(keyGenParameterSpec)
                 .build()
 
@@ -89,7 +92,7 @@ class SettingsStorage(private val context: Context) {
         val encryptedFile = EncryptedFile.Builder(
             secureFile,
             context.applicationContext,
-            masterKeyAlias,
+            DEFAULT_MASTER_KEY_ALIAS,
             EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
         ).build()
 

--- a/app/src/main/java/network/photos/android/data/user/storage/UserStorage.kt
+++ b/app/src/main/java/network/photos/android/data/user/storage/UserStorage.kt
@@ -22,30 +22,35 @@ class UserStorage(context: Context) {
 
     init {
         try {
-            val keyGenParameterSpec = KeyGenParameterSpec
-                .Builder(
-                    MasterKey.DEFAULT_MASTER_KEY_ALIAS,
-                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-                )
-                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
-                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setKeySize(MasterKey.DEFAULT_AES_GCM_MASTER_KEY_SIZE)
-                .build()
-
-            masterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
-                .setKeyGenParameterSpec(keyGenParameterSpec)
-                .build()
-
-            encryptedFile = EncryptedFile.Builder(
-                context.applicationContext,
-                secureFile,
-                masterKey,
-                EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
-            ).build()
+            initialize(context)
         } catch (e: Exception) {
             Log.e("UserStorage", "\uD83D\uDC80 EXCEPTION!!", e)
             delete()
+            initialize(context)
         }
+    }
+
+    private fun initialize(context: Context) {
+        val keyGenParameterSpec = KeyGenParameterSpec
+            .Builder(
+                MasterKey.DEFAULT_MASTER_KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(MasterKey.DEFAULT_AES_GCM_MASTER_KEY_SIZE)
+            .build()
+
+        masterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+            .setKeyGenParameterSpec(keyGenParameterSpec)
+            .build()
+
+        encryptedFile = EncryptedFile.Builder(
+            context.applicationContext,
+            secureFile,
+            masterKey,
+            EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
+        ).build()
     }
 
     fun save(user: User) {

--- a/app/src/main/java/network/photos/android/data/user/storage/UserStorage.kt
+++ b/app/src/main/java/network/photos/android/data/user/storage/UserStorage.kt
@@ -14,7 +14,6 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 
 class UserStorage(context: Context) {
-    private val masterKeyAlias = "user_storage"
     private val filename = "user_storage.txt"
     private val gson: Gson = GsonBuilder().create()
     private val secureFile = File(context.filesDir, filename)
@@ -23,15 +22,17 @@ class UserStorage(context: Context) {
 
     init {
         try {
-            val keyGenParameterSpec = KeyGenParameterSpec.Builder(
-                masterKeyAlias,
-                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
-            ).setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            val keyGenParameterSpec = KeyGenParameterSpec
+                .Builder(
+                    MasterKey.DEFAULT_MASTER_KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+                )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
-                .setKeySize(256)
+                .setKeySize(MasterKey.DEFAULT_AES_GCM_MASTER_KEY_SIZE)
                 .build()
 
-            masterKey = MasterKey.Builder(context, masterKeyAlias)
+            masterKey = MasterKey.Builder(context, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
                 .setKeyGenParameterSpec(keyGenParameterSpec)
                 .build()
 

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <exclude domain="sharedpref" path="settings_storage.txt"/>
-    <exclude domain="sharedpref" path="user_storage.txt"/>
+    <exclude domain="file" path="user_storage.txt"/>
+    <exclude domain="file" path="settings_storage.txt"/>
+    <exclude domain="sharedpref" path="__androidx_security_crypto_encrypted_file_pref__.xml"/>
 </full-backup-content>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" path="."/>
+    <exclude domain="file" path="settings_storage.txt"/>
+    <exclude domain="file" path="user_storage.txt"/>
+</full-backup-content>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <exclude domain="sharedpref" path="."/>
-    <exclude domain="file" path="settings_storage.txt"/>
-    <exclude domain="file" path="user_storage.txt"/>
+    <exclude domain="sharedpref" path="settings_storage.txt"/>
+    <exclude domain="sharedpref" path="user_storage.txt"/>
 </full-backup-content>


### PR DESCRIPTION
Exclude encrypted files from auto backup to prevent decryption errors like: AEADBadTagException