### PR TITLE
Disable gradle publishing plugin for non-release buils

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,9 @@ val releaseKeyPassword: String by project
 
 // deployment
 play {
+    // publishing will be enabled for release flavor only
+    enabled.set(false)
+
     serviceAccountCredentials.set(rootProject.file("gradle_playstore_publisher_credentials.json"))
     defaultToAppBundles.set(true)
 
@@ -158,6 +161,13 @@ android {
             storePassword = releaseStorePassword
             keyAlias = releaseKeyAlias
             keyPassword = releaseKeyPassword
+        }
+    }
+
+    (this as ExtensionAware).extensions.configure<
+            NamedDomainObjectContainer<com.github.triplet.gradle.play.PlayPublisherExtension>>("playConfigs") {
+        register("release") {
+            enabled.set(true)
         }
     }
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
To simplify local build and test runs, disable gradle publisher requirement of having valid credentials for non-release buils

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
