### PR TITLE
Enable the secure flags only when it is not a debug build

### DIFF
--- a/app/src/main/kotlin/photos/network/MainActivity.kt
+++ b/app/src/main/kotlin/photos/network/MainActivity.kt
@@ -56,7 +56,7 @@ class MainActivity : ComponentActivity() {
         if (!BuildConfig.DEBUG) {
             window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
+                WindowManager.LayoutParams.FLAG_SECURE,
             )
         }
 

--- a/app/src/main/kotlin/photos/network/MainActivity.kt
+++ b/app/src/main/kotlin/photos/network/MainActivity.kt
@@ -53,7 +53,12 @@ class MainActivity : ComponentActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+        if (!BuildConfig.DEBUG) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
 
         setContent {
             PhotosApp(


### PR DESCRIPTION
## 📑 Description
The developer is not able to see their device mirrored in Android Studio when the FLAG_SECURE is set. It should only be enabled for non-debug builds.
